### PR TITLE
Tool: view pdf attachments directly (raw view)

### DIFF
--- a/markdown/backend/optimization.md
+++ b/markdown/backend/optimization.md
@@ -19,7 +19,7 @@ outcomes:
   - k1: "Maschinenabhängige Optimierungen"
   - k1: "Datenflussanalyse auf 3-Adress-Code"
 attachments:
-  - link: "https://github.com/Compiler-CampusMinden/AnnotatedSlides/blob/master/optimization.ann.ma.pdf"
+  - link: "https://raw.githubusercontent.com/Compiler-CampusMinden/AnnotatedSlides/master/optimization.ann.ma.pdf"
     name: "Annotierte Folien: Optimierung und Datenflussanalyse"
 ---
 

--- a/markdown/frontend/lexing/regular.md
+++ b/markdown/frontend/lexing/regular.md
@@ -20,7 +20,7 @@ outcomes:
   - k3: "Herausfinden, ob eine Sprache regulär ist"
   - k3: "Einen DFA entwickeln, der alle Schlüsselwörter, Namen und weitere Symbole einer Programmiersprache akzeptiert"
 attachments:
-  - link: "https://github.com/Compiler-CampusMinden/AnnotatedSlides/blob/master/lexing_regular.ann.ma.pdf"
+  - link: "https://raw.githubusercontent.com/Compiler-CampusMinden/AnnotatedSlides/master/lexing_regular.ann.ma.pdf"
     name: "Annotierte Folien: Reguläre Sprachen, Ausdrucksstärke"
 ---
 

--- a/markdown/frontend/parsing/cfg.md
+++ b/markdown/frontend/parsing/cfg.md
@@ -13,7 +13,7 @@ outcomes:
   - k1: "Deterministisch kontextfreie Grammatiken"
   - k2: "Zusammenhang zwischen PDAs und kontextfreien Grammatiken"
 attachments:
-  - link: "https://github.com/Compiler-CampusMinden/AnnotatedSlides/blob/master/frontend_parsing_cfg.ann.ma.pdf"
+  - link: "https://raw.githubusercontent.com/Compiler-CampusMinden/AnnotatedSlides/master/frontend_parsing_cfg.ann.ma.pdf"
     name: "Annotierte Folien: CFG, LL-Parser"
 
 ---

--- a/markdown/frontend/parsing/ll-parser-theory.md
+++ b/markdown/frontend/parsing/ll-parser-theory.md
@@ -15,7 +15,7 @@ outcomes:
   - k2: "Schreiben von LL-Parsern"
   - k3: "Top-Down Analyse programmieren"
 attachments:
-  - link: "https://github.com/Compiler-CampusMinden/AnnotatedSlides/blob/master/ll-parser-theory.ann.ma.pdf"
+  - link: "https://raw.githubusercontent.com/Compiler-CampusMinden/AnnotatedSlides/master/ll-parser-theory.ann.ma.pdf"
     name: "Annotierte Folien: LL-Parser (Theorie)"
 ---
 

--- a/markdown/frontend/parsing/lr-parser1.md
+++ b/markdown/frontend/parsing/lr-parser1.md
@@ -20,7 +20,7 @@ outcomes:
   - k3: "Konstruktion der Parse Tables"
   - k3: "Durchführen des Parsens"
 attachments:
-  - link: "https://github.com/Compiler-CampusMinden/AnnotatedSlides/blob/master/lr-parser1.ann.ma.pdf"
+  - link: "https://raw.githubusercontent.com/Compiler-CampusMinden/AnnotatedSlides/master/lr-parser1.ann.ma.pdf"
     name: "Annotierte Folien: LR-Parser1"
 ---
 

--- a/markdown/frontend/parsing/lr-parser2.md
+++ b/markdown/frontend/parsing/lr-parser2.md
@@ -23,7 +23,7 @@ outcomes:
   - k3: "Konstruktion der Parse Tables"
   - k3: "Durchführen des Parsens"
 attachments:
-  - link: "https://github.com/Compiler-CampusMinden/AnnotatedSlides/blob/master/lr-parser2.ann.ma.pdf"
+  - link: "https://raw.githubusercontent.com/Compiler-CampusMinden/AnnotatedSlides/master/lr-parser2.ann.ma.pdf"
     name: "Annotierte Folien: LR-Parser2"
 ---
 

--- a/markdown/frontend/parsing/parsercombinator.md
+++ b/markdown/frontend/parsing/parsercombinator.md
@@ -14,7 +14,7 @@ outcomes:
   - k1: "Top Down Operator Precedence (Pratt) Parser"
   - k1: "Parser-Kombinatoren"
 attachments:
-  - link: "https://github.com/Compiler-CampusMinden/AnnotatedSlides/blob/master/parsercombinator.ann.ma.pdf"
+  - link: "https://raw.githubusercontent.com/Compiler-CampusMinden/AnnotatedSlides/master/parsercombinator.ann.ma.pdf"
     name: "Annotierte Folien: PEG-Parser, Pratt-Parser und Parser Combinators"
 ---
 

--- a/markdown/frontend/semantics/attribgrammars.md
+++ b/markdown/frontend/semantics/attribgrammars.md
@@ -14,7 +14,7 @@ outcomes:
   - k2: "Umsetzung von SDD mit Hilfe von SDT"
   - k3: "Einfache semantische Analyse mit Hilfe von attributierten Grammatiken"
 attachments:
-  - link: "https://github.com/Compiler-CampusMinden/AnnotatedSlides/blob/master/semantics_attribgrammars.ann.ma.pdf"
+  - link: "https://raw.githubusercontent.com/Compiler-CampusMinden/AnnotatedSlides/master/semantics_attribgrammars.ann.ma.pdf"
     name: "Annotierte Folien: Typen, Type Checking und attributierte Grammatiken"
 ---
 

--- a/markdown/intermediate/llvm-ir.md
+++ b/markdown/intermediate/llvm-ir.md
@@ -11,7 +11,7 @@ outcomes:
   - k1: "Module von LLVM"
   - k1: "SSA"
 attachments:
-  - link: "https://github.com/Compiler-CampusMinden/AnnotatedSlides/blob/master/llvm-ir.ann.ma.pdf"
+  - link: "https://raw.githubusercontent.com/Compiler-CampusMinden/AnnotatedSlides/master/llvm-ir.ann.ma.pdf"
     name: "Annotierte Folien: LLVM-IR"
 ---
 


### PR DESCRIPTION
Nutze die URL `raw.githubusercontent.com`, um die PDF-Attachments zu verlinken. Dadurch werden sie direkt angezeigt (in der "normalen" Ansicht sieht man nur die ersten 2..3 Seiten und muss dann mühsam vorwärtsklicken und die nächsten Seiten "freischalten").