### PR TITLE
Tool: switch to 'default' layout for chapter landing pages

### DIFF
--- a/admin/readme.md
+++ b/admin/readme.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Organisatorisches"
 
 hidden: true

--- a/homework/readme.md
+++ b/homework/readme.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Praktikum"
 
 hidden: true

--- a/lecture/backend/interpretation/readme.md
+++ b/lecture/backend/interpretation/readme.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Interpreter"
 ---
 

--- a/lecture/backend/readme.md
+++ b/lecture/backend/readme.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Backend"
 ---
 

--- a/lecture/frontend/lexing/readme.md
+++ b/lecture/frontend/lexing/readme.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Lexer"
 ---
 

--- a/lecture/frontend/parsing/readme.md
+++ b/lecture/frontend/parsing/readme.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Parser"
 ---
 

--- a/lecture/frontend/readme.md
+++ b/lecture/frontend/readme.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Frontend"
 ---
 

--- a/lecture/frontend/semantics/readme.md
+++ b/lecture/frontend/semantics/readme.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Semantische Analyse"
 ---
 

--- a/lecture/frontend/semantics/symboltables/readme.md
+++ b/lecture/frontend/semantics/symboltables/readme.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Symboltabellen"
 ---
 

--- a/lecture/intermediate/readme.md
+++ b/lecture/intermediate/readme.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Zwischencode"
 ---
 

--- a/lecture/intro/readme.md
+++ b/lecture/intro/readme.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Überblick"
 ---
 

--- a/lecture/readme.md
+++ b/lecture/readme.md
@@ -1,5 +1,5 @@
 ---
-archetype: "chapter"
+archetype: "default"
 title: "Vorlesungsunterlagen"
 menutitle: "Vorlesung"
 ---


### PR DESCRIPTION
Das `chapter`-Template ist irgendwie kaputt: Die Fußzeile wird viel zu groß dargestellt. Das betrifft auch das originale `chapter`-Template ... Wir wechseln hier auf das `default`-Template, wodurch die Fußzeile wieder passt. Einzig der `<hr>` unter dem Titel fehlt ...