### PR TITLE
Lecture: move math out of image caption (cfg.md)

### DIFF
--- a/lecture/frontend/parsing/cfg.md
+++ b/lecture/frontend/parsing/cfg.md
@@ -79,8 +79,9 @@ Soll das automatisch vom Stack genommene Symbol auf dem Stack bleiben, muss es w
 
 ## Beispiel
 
+Ein PDA für $L=\lbrace ww^{R}\mid w\in \lbrace a,b\rbrace^{\ast}\rbrace$:
 
-![Ein PDA für $L=\lbrace ww^{R}\mid w\in \lbrace a,b\rbrace^{\ast}\rbrace$](images/pda2.png){width="45%"}
+![](images/pda2.png){width="45%"}
 
 
 ## Konfigurationen von PDAs


### PR DESCRIPTION
math inside an image caption seems to be not working w/ hugo