### PR TITLE
Lecture: move math out of image caption (lrparser1.md)

### DIFF
--- a/lecture/frontend/parsing/lr-parser1.md
+++ b/lecture/frontend/parsing/lr-parser1.md
@@ -27,7 +27,11 @@ attachments:
 # Wiederholung
 <!-- 10 Minuten: 1 Folie -->
 
-<!--![Ein PDA für $L=\lbrace ww^{R}\mid w\in \lbrace a,b\rbrace^{\ast}\rbrace$](images/pda.png){width="60%"} -->
+<!--
+Ein PDA für $L=\lbrace ww^{R}\mid w\in \lbrace a,b\rbrace^{\ast}\rbrace$:
+
+![](images/pda.png){width="60%"}
+-->
 
 ## Top-Down-Analyse
 


### PR DESCRIPTION
math inside an image caption seems to be not working w/ hugo