### PR TITLE
Lecture: move math out of image caption (lrparser2.md)

### DIFF
--- a/lecture/frontend/parsing/lr-parser2.md
+++ b/lecture/frontend/parsing/lr-parser2.md
@@ -30,7 +30,9 @@ attachments:
 # Wiederholung
 <!-- 10 Minuten: 1 Folie -->
 
-![Ein PDA für $L=\lbrace ww^{R}\mid w\in \lbrace a,b\rbrace^{\ast}\rbrace$](images/pda.png){width="60%"}
+Ein PDA für $L=\lbrace ww^{R}\mid w\in \lbrace a,b\rbrace^{\ast}\rbrace$:
+
+![](images/pda.png){width="60%"}
 
 ## Top-Down-Analyse
 


### PR DESCRIPTION
math inside an image caption seems to be not working w/ hugo