### PR TITLE
org: adapt planning of talks

### DIFF
--- a/homework/project.md
+++ b/homework/project.md
@@ -52,4 +52,4 @@ Es gibt drei vordefinierte Meilensteine:
 Im Rahmen des **Vortrags II** sollen am Ende des Semesters die Projektergebnisse gemeinsam vorgestellt werden.
 
 **Hinweis zu Meilenstein 2**:
-Stellen Sie gemeinsam als Gruppe das Projekt den Studierenden der University of Alberta vor: Was ist die Aufgabe, welche Konzepte und Strukturen haben Sie erarbeitet, wie sehen erste Arbeitsergebnisse aus? Jede(r) sollte ca. 10 Minuten vortragen. Dieser Vortrag findet in englischer Sprache statt und ist Teil der Prüfungsleistung.
+Stellen Sie gemeinsam als Gruppe das Projekt den Studierenden der University of Alberta vor: Was ist die Aufgabe, welche Konzepte und Strukturen haben Sie erarbeitet, wie sehen erste Arbeitsergebnisse aus? Jede(r) sollte ca. 5 Minuten vortragen. Dieser Vortrag findet in englischer Sprache statt und ist Teil der Prüfungsleistung.

--- a/homework/project.md
+++ b/homework/project.md
@@ -52,4 +52,4 @@ Es gibt drei vordefinierte Meilensteine:
 Im Rahmen des **Vortrags II** sollen am Ende des Semesters die Projektergebnisse gemeinsam vorgestellt werden.
 
 **Hinweis zu Meilenstein 2**:
-Stellen Sie gemeinsam als Gruppe das Projekt den Studierenden der University of Alberta vor: Was ist die Aufgabe, welche Konzepte und Strukturen haben Sie erarbeitet, wie sehen erste Arbeitsergebnisse aus? Jede(r) sollte ca. 5 Minuten vortragen. Dieser Vortrag findet in englischer Sprache statt und ist Teil der Prüfungsleistung.
+Stellen Sie gemeinsam als Gruppe das Projekt den Studierenden der University of Alberta vor: Was ist die Aufgabe, welche Konzepte und Strukturen haben Sie erarbeitet, wie sehen erste Arbeitsergebnisse aus? Jede(r) sollte ca. 6 Minuten vortragen. Dieser Vortrag findet in englischer Sprache statt und ist Teil der Prüfungsleistung.

--- a/homework/talk.md
+++ b/homework/talk.md
@@ -7,7 +7,7 @@ hidden: true
 ---
 
 
-Der Vortrag III ist Teil der Prüfungsleistung für Studierende, die nach der neuen Prüfungsordnung (PO23) am Modul "Concepts of Programming Languages" teilnehmen. Die Vorträge sollen 30 Minuten dauern und werden in der letzten Vorlesungswoche stattfinden. Planen Sie eine Diskussion von ca. 10 Minuten ein. Zusätzlich ist eine kurze Zusammenfassung des Vortrags als Blog im Discussions-Thread des jeweiligen Exposés zu erstellen.
+Der Vortrag III ist Teil der Prüfungsleistung für Studierende, die nach der neuen Prüfungsordnung (PO23) am Modul "Concepts of Programming Languages" teilnehmen. Die Vorträge sollen 20 Minuten dauern und werden in der letzten Vorlesungswoche stattfinden. Planen Sie eine Diskussion von zusätzlich ca. 10 Minuten ein. Zusätzlich ist eine kurze Zusammenfassung des Vortrags als Blog im Discussions-Thread des jeweiligen Exposés zu erstellen.
 
 Wir bieten Ihnen hier verschiedene Themen zur Auswahl an, Sie können aber auch gern eigene Vorschläge erarbeiten. Erstellen Sie in beiden Fällen ein kurzes Exposé (Thema, Kernthesen, Paper) als neuen Beitrag in den [GitHub-Discussions](https://github.com/Compiler-CampusMinden/CB-Vorlesung-Master/discussions/new?category=vortrag-iii) und stimmen Sie dieses bis zum Meilenstein I mit Ihren Dozent:innen ab. Ein Thema (bezogen auf die genutzten Paper/Quellen) kann nur einmal vergeben werden - hier gilt das _first-come-first-serve_-Prinzip in den Discussions.
 

--- a/readme.md
+++ b/readme.md
@@ -110,8 +110,8 @@ alle Sitzungen online/per Zoom (**Zugangsdaten siehe [ILIAS]**)
     Kriterien:
     *   Aktive Mitarbeit im [Praktikum] und an den Meilensteinen
     *   Aktive Teilnahme an den drei gemeinsamen Terminen mit der University of Alberta (Edmonton)
-    *   Vortrag I mit Edmonton zu Spezialisierung/Baustein in Projekt, ca. 10 Minuten pro Person (60 bis 90 Minuten gesamt)
-    *   Vortrag II: Vorstellung der Projektergebnisse, ca. 10 Minuten pro Person (60 bis 90 Minuten gesamt)
+    *   Vortrag I mit Edmonton zu Spezialisierung/Baustein in Projekt, ca. 5 Minuten pro Person (60 bis 90 Minuten gesamt)
+    *   Vortrag II: Vorstellung der Projektergebnisse, ca. 10 Minuten pro Person (2x 90 Minuten gesamt)
 
 *   **Gesamtnote**:
     Mündliche Prüfung am Ende des Semesters, angeboten in beiden Prüfungszeiträumen.
@@ -123,12 +123,10 @@ alle Sitzungen online/per Zoom (**Zugangsdaten siehe [ILIAS]**)
 
 *   **unbenotet**: Aktive Mitarbeit im [Praktikum] und an den Meilensteinen
 *   **unbenotet**: Aktive Teilnahme an den drei gemeinsamen Terminen mit der University of Alberta (Edmonton)
-*   **unbenotet**: Vortrag I mit Edmonton zu Spezialisierung/Baustein in Projekt,
-    ca. 10 Minuten pro Person (60 bis 90 Minuten gesamt)
-*   **unbenotet**: Vortrag II: Vorstellung der Projektergebnisse, ca. 10 Minuten pro Person (60 bis 90 Minuten gesamt)
+*   **unbenotet**: Vortrag I mit Edmonton zu Spezialisierung/Baustein in Projekt, ca. 5 Minuten pro Person (60 bis 90 Minuten gesamt)
+*   **unbenotet**: Vortrag II: Vorstellung der Projektergebnisse, ca. 10 Minuten pro Person (2x 90 Minuten gesamt)
 *   **benotet (30%)**: [Vortrag III]: Vortrag zu Paper-Analyse (extra-Leistung neue PO)
-    plus Diskussion (Vorbereitung/Leitung), 30 Minuten Dauer; Zusammenfassung als
-    Blog-Eintrag
+    plus Diskussion (Vorbereitung/Leitung), 30 Minuten Dauer (Vortrag+Diskussion); Zusammenfassung als Blog-Eintrag
 *   **benotet (70%)**: Mündliche Prüfung am Ende des Semesters, angeboten in beiden Prüfungszeiträumen
 
 **Gesamtnote: 30% Vortrag III plus 70% mdl. Prüfung**

--- a/readme.md
+++ b/readme.md
@@ -110,8 +110,8 @@ alle Sitzungen online/per Zoom (**Zugangsdaten siehe [ILIAS]**)
     Kriterien:
     *   Aktive Mitarbeit im [Praktikum] und an den Meilensteinen
     *   Aktive Teilnahme an den drei gemeinsamen Terminen mit der University of Alberta (Edmonton)
-    *   Vortrag I mit Edmonton zu Spezialisierung/Baustein in Projekt, ca. 5 Minuten pro Person (60 bis 90 Minuten gesamt)
-    *   Vortrag II: Vorstellung der Projektergebnisse, ca. 10 Minuten pro Person (2x 90 Minuten gesamt)
+    *   Vortrag I mit Edmonton zu Spezialisierung/Baustein in Projekt, ca. 6 Minuten pro Person (60 bis 90 Minuten gesamt)
+    *   Vortrag II: Vorstellung der Projektergebnisse, ca. 12 Minuten pro Person (2x 90 Minuten gesamt)
 
 *   **Gesamtnote**:
     Mündliche Prüfung am Ende des Semesters, angeboten in beiden Prüfungszeiträumen.
@@ -123,10 +123,10 @@ alle Sitzungen online/per Zoom (**Zugangsdaten siehe [ILIAS]**)
 
 *   **unbenotet**: Aktive Mitarbeit im [Praktikum] und an den Meilensteinen
 *   **unbenotet**: Aktive Teilnahme an den drei gemeinsamen Terminen mit der University of Alberta (Edmonton)
-*   **unbenotet**: Vortrag I mit Edmonton zu Spezialisierung/Baustein in Projekt, ca. 5 Minuten pro Person (60 bis 90 Minuten gesamt)
-*   **unbenotet**: Vortrag II: Vorstellung der Projektergebnisse, ca. 10 Minuten pro Person (2x 90 Minuten gesamt)
+*   **unbenotet**: Vortrag I mit Edmonton zu Spezialisierung/Baustein in Projekt, ca. 6 Minuten pro Person (60 bis 90 Minuten gesamt)
+*   **unbenotet**: Vortrag II: Vorstellung der Projektergebnisse, ca. 12 Minuten pro Person (2x 90 Minuten gesamt)
 *   **benotet (30%)**: [Vortrag III]: Vortrag zu Paper-Analyse (extra-Leistung neue PO)
-    plus Diskussion (Vorbereitung/Leitung), 30 Minuten Dauer (Vortrag+Diskussion); Zusammenfassung als Blog-Eintrag
+    plus Diskussion (Vorbereitung/Leitung), 30 Minuten Dauer (20' Vortrag + 10' Diskussion); Zusammenfassung als Blog-Eintrag
 *   **benotet (70%)**: Mündliche Prüfung am Ende des Semesters, angeboten in beiden Prüfungszeiträumen
 
 **Gesamtnote: 30% Vortrag III plus 70% mdl. Prüfung**


### PR DESCRIPTION
Wir haben vorläufig folgende Zahlen:

- PO23: 6 TN
- PO18: 7 TN

Stand 15.11.: 13 TN.

Das sprengt bei den Vorträgen die bisherige vorläufige Planung, die Zeiten/Dauern müssen entsprechend angepasst werden. Vorläufige Idee:

- Edmonton II: ca. 60..90 Minuten: 90'/13 TN => ca. 6'/Person (plus Wechsel)
- Vortrag II: VL- und P-Slot zusammenfassen: 2x90' => ca. 12'/Person
- Vortrag III: 6x (20' Talk + 10' Discussion) = 3h bzw. 2x 90'

---

Dieser PR passt die Planung der Vorträge (eigentlich nur die Dauer) an die Anzahl der TN an.

TODO: Vor dem Merge noch die Einträge in den Discussions anpassen (Announcements)

- [x] https://github.com/Compiler-CampusMinden/CB-Vorlesung-Master/discussions/89
- [x] https://github.com/Compiler-CampusMinden/CB-Vorlesung-Master/discussions/90
- [x] https://github.com/Compiler-CampusMinden/CB-Vorlesung-Master/discussions/39
