### PR TITLE
fix link to proposed paper for testing talk

### DIFF
--- a/homework/talk.md
+++ b/homework/talk.md
@@ -44,7 +44,7 @@ Wir bieten Ihnen hier verschiedene Themen zur Auswahl an, Sie können aber auch 
     -   T. Parr: [_LL(\*) grammar analysis_](https://theantlrguy.atlassian.net/wiki/spaces/~admin/pages/524294/LL+grammar+analysis)
 8.  Testing:
     -   [Finding and Understanding Bugs in C Compilers](https://users.cs.utah.edu/~regehr/papers/pldi11-preprint.pdf)
-    -   [Validating JIT Compilers via Compilation Space Exploration](https://connglli.github.io/pdfs/artemis_sosp23_preprint.pdf)
+    -   [Validating JIT Compilers via Compilation Space Exploration](https://connglli.github.io/pdfs/artemis_sosp23.pdf)
     -   [A Survey of Compiler Testing](https://software-lab.org/publications/csur2019_compiler_testing.pdf)
     -   [An empirical comparison of compiler testing techniques](https://xiongyingfei.github.io/papers/ICSE16.pdf)
     -   [Compiler Testing: A Systematic Literature Analysis](https://arxiv.org/abs/1810.02718)


### PR DESCRIPTION
paper link changed because the paper left the preprint status