### PR TITLE
lecture: fix resolving in classes

### DIFF
--- a/lecture/frontend/semantics/symboltables/classes.md
+++ b/lecture/frontend/semantics/symboltables/classes.md
@@ -215,21 +215,26 @@ class Clazz(Struct):
         # do we know "name" here?
         if symbols[name]: return symbols[name]
         # NEW: if not here, check any parent class ...
-        if parentClazz != None: return parentClazz.resolve(name)
-        # ... or enclosing scope if base class
-        try: return enclosingScope.resolve(name)
-        except: return None     # not found
+        if parentClazz and parentClazz.resolve(name): return parentClazz.resolve(name)
+        else:
+            # ... or enclosing scope if base class
+            if enclosingScope: return enclosingScope.resolve(name)
+            else: return None     # not found
 
     def resolveMember(name):
         if symbols[name]: return symbols[name]
         # NEW: check parent class
-        try: return parentClazz.resolveMember(name)
-        except: return None
+        if parentClazz: return parentClazz.resolveMember(name)
+        else: return None
 ```
 
 [Quelle: Eigene Implementierung nach einer Idee in [@Parr2010, p. 172]]{.origin}
 
 ::: notes
+**Hinweis**: Die obige Implementierungsskizze soll vor allem das Prinzip demonstrieren - sie ist aus
+Gründen der Lesbarkeit nicht besonders effizient: beispielsweise wird `parentClazz.resolve(name)`
+mehrfach evaluiert ...
+
 Beim Auflösen von Attributen oder Methoden muss zunächst in der Klasse selbst gesucht werden,
 anschließend in der Elternklasse.
 

--- a/lecture/frontend/semantics/symboltables/scopes.md
+++ b/lecture/frontend/semantics/symboltables/scopes.md
@@ -191,8 +191,8 @@ class Scope:
         # do we know "name" here?
         if symbols[name]: return symbols[name]
         # if not here, check any enclosing scope
-        try: return enclosingScope.resolve(name)
-        except: return None     # not found
+        if enclosingScope: return enclosingScope.resolve(name)
+        else: return None     # not found
 
     def bind(symbol):
         symbols[symbol.name] = symbol


### PR DESCRIPTION
Das Auflösen von Namen bei Klassen funktioniert nicht korrekt: Wenn es eine Elternklasse gab, wurde nur dort nachgeschaut - auch, wenn das Symbol dort nicht gefunden werden konnte.

Siehe Diskussion in https://github.com/Compiler-CampusMinden/CB-Vorlesung-Master/issues/140: 


1. Wenn ich Funktionen betrachte:

```java
class Y {}

class X extends Y {
    int f(int z) { return z; }
}

class Z {
    int f(int z) { return z; }

    class W extends X {
        int f(int z) { return z; }

        void foo() {
            f(34);
        }
    }
}
```

Beim Aufruf von `f(34)` in `void foo()` versuche ich, die Funktion in der Klasse (also `Z.W`) aufzulösen. Wenn ich sie dort nicht finde, gehe ich in die Elternklasse von `W`, also `X` (und so weiter). Erst wenn ich die Funktion auf diesem Wege nicht finden kann, suche ich im _enclosing scope_ der Klasse `W`, also in `Z`.


2. Wenn ich Attribute/Variablen betrachte:

```java
class Y {}

class X extends Y {
    int x = 1;
}

class Z {
    int x = 3;

    class W extends X {
        int x = 2;

        void foo() {
            System.out.println(x);
        }
    }
}
```

Auch hier würde ich im `System.out.println(x)` zunächst im _enclosing scope_ suchen, also in der Klasse `W`. Wenn ich dort nicht fündig werde, gehe ich zur Elternklasse (`X`) ... Danach suche ich dann im _enclosing scope_ der Klasse `W`, also in `Z` weiter.


Insofern ist der Code-Schnipsel im Skript nicht ganz korrekt, jedenfalls nicht in Bezug auf die Semantik in Java :)  Dein Code-Vorschlag löst das ein wenig besser auf, aber am Ende gibt es ja eine Exception, wenn das Element nicht gefunden wird - ich glaube, wir brauchen einfach nur eine doppelte `try`/`catch`-Struktur?

```
    # NEW: if not here, check any parent class ...
    if parentClazz and parentClazz.resolve(name): return parentClazz.resolve(name)
    else: 
        # ... or enclosing scope if base class
        if enclosingScope: return enclosingScope.resolve(name)
        else: return None     # not found
```


fixes https://github.com/Compiler-CampusMinden/CB-Vorlesung-Master/issues/140
